### PR TITLE
expose result to mapStateToProps() to context

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52,7 +52,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -70,9 +70,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = _connect2.default;
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -90,10 +90,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	var createListener = function createListener(context, mapState, store) {
 	  var prevState = void 0;
 	  var listener = function listener(state) {
+	    prevState = context.props;
 	    var nextState = mapState(state);
 	    if (!prevState || !(0, _utils.shallowEqual)(nextState, prevState)) {
 	      prevState = Object.assign({}, nextState);
 	      context.onStateChange.call(context, nextState);
+	      context.props = prevState;
 	    }
 	  };
 
@@ -229,9 +231,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 	module.exports = exports['default'];
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -291,7 +293,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.shallowEqual = shallowEqual;
 	exports.callInContext = callInContext;
 
-/***/ }
+/***/ })
 /******/ ])
 });
 ;

--- a/es6/connect.js
+++ b/es6/connect.js
@@ -6,10 +6,12 @@ const listeners = []
 const createListener = (context, mapState, store) => {
   let prevState
   const listener = function(state){
+    prevState = context.props;
     const nextState = mapState(state)
     if(!prevState || !shallowEqual(nextState, prevState)){
       prevState = Object.assign({}, nextState)
       context.onStateChange.call(context, nextState)
+      context.props = prevState;
     }
   }
 


### PR DESCRIPTION
在监听方法中的 prevState 一直是null，因此当状态改变时，shallowEqual 并无法正确的工作。

如果pr没有问题的话，请麻烦 npm publish 一个新版本上去吧。

谢谢